### PR TITLE
Add video recording controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ def __init__(self, device="/dev/video0"):  # or your device path
 3. Images are saved to `./timelapse/` directory
 4. Click "Stop Timelapse" to end capture
 
+### Video Recording
+
+1. Click "Start Recording" to begin capturing video
+2. The recorded file is saved under `./videos/` directory
+3. Click "Stop Recording" to end capture
+
 ## 📡 API Endpoints
 
 ### Web Interface
@@ -139,6 +145,8 @@ def __init__(self, device="/dev/video0"):  # or your device path
   ```
 
 - `POST /stop_timelapse` - Stop timelapse capture
+- `POST /start_recording` - Begin video recording
+- `POST /stop_recording` - Stop video recording
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
## Summary
- add `VideoRecorder` class for saving video from the camera
- expose `/start_recording` and `/stop_recording` endpoints
- add buttons and JS handlers for video recording in the web UI
- include recording info in README

## Testing
- `python3 -m py_compile app/camera_server.py`

------
https://chatgpt.com/codex/tasks/task_e_688a65baa738832c976cb93210770808