### PR TITLE
Fix camera detection order

### DIFF
--- a/app/camera_server.py
+++ b/app/camera_server.py
@@ -38,6 +38,13 @@ def discover_cameras():
                 i += 1
         else:
             i += 1
+
+    # Sort devices numerically so /dev/video0 comes before /dev/video10
+    def dev_index(dev_path):
+        m = re.search(r"/dev/video(\d+)", dev_path)
+        return int(m.group(1)) if m else 0
+
+    cameras.sort(key=lambda x: dev_index(x[1]))
     return cameras
 
 class ThreadSafeCameraController:


### PR DESCRIPTION
## Summary
- ensure camera detection chooses the lowest video index first by sorting results from `v4l2-ctl`

## Testing
- `python3 -m py_compile app/camera_server.py`

------
https://chatgpt.com/codex/tasks/task_e_688a9d756d10832c94dfb11bb638c373