### PR TITLE
Fix preview orientation after resolution change

### DIFF
--- a/app/camera_server.py
+++ b/app/camera_server.py
@@ -713,6 +713,20 @@ def index():
                 }
             }
 
+            function updatePreviewSize(w, h) {
+                const img = document.getElementById("videoStream");
+                if (!img) return;
+                const maxDim = 800;
+                const aspect = w / h;
+                if (aspect >= 1) {
+                    img.style.width = maxDim + "px";
+                    img.style.height = Math.round(maxDim / aspect) + "px";
+                } else {
+                    img.style.height = maxDim + "px";
+                    img.style.width = Math.round(maxDim * aspect) + "px";
+                }
+            }
+
             function changeResolution() {
                 const [fmt, w, h] = document.getElementById("resolution").value.split(",");
                 fetch("/set_resolution", {
@@ -721,6 +735,7 @@ def index():
                     body: JSON.stringify({ width: parseInt(w), height: parseInt(h), format: fmt })
                 }).then(() => {
                     document.getElementById("videoStream").src = "/video_feed?t=" + new Date().getTime();
+                    updatePreviewSize(parseInt(w), parseInt(h));
                 });
             }
 
@@ -764,6 +779,11 @@ def index():
                 }).then(resp => resp.json())
                   .then(data => alert(data.message));
             }
+
+            window.addEventListener('load', () => {
+                const [fmt, w, h] = document.getElementById("resolution").value.split(',');
+                updatePreviewSize(parseInt(w), parseInt(h));
+            });
 
 
         </script>


### PR DESCRIPTION
## Summary
- scale preview image to match selected resolution orientation

## Testing
- `python3 -m py_compile app/camera_server.py`

------
https://chatgpt.com/codex/tasks/task_e_688bc6af7128832cb8da4fc647535629