### PR TITLE
Fix running app.app directly

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,8 +9,16 @@ import sys
 import re
 import os
 
-from .utils.config import load_config, persist_config
-from .camera.controller import ThreadSafeCameraController
+# Allow this module to be executed directly as a script by adjusting
+# the import paths when no parent package is detected.
+if __package__ is None or __package__ == "":
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, os.path.abspath(os.path.join(script_dir, "..")))
+    from utils.config import load_config, persist_config
+    from camera.controller import ThreadSafeCameraController
+else:
+    from .utils.config import load_config, persist_config
+    from .camera.controller import ThreadSafeCameraController
 
 app = Flask(__name__)
 camera = None


### PR DESCRIPTION
## Summary
- support executing `app/app.py` directly

## Testing
- `python -m app.app` (fails due to missing flask, as expected)

------
https://chatgpt.com/codex/tasks/task_e_688cd47f2d4c832c849e108cbc2c4b6a