### PR TITLE
Save camera settings in config

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -365,6 +365,11 @@ def save_config_route():
         config["image_output"] = img
     if vid:
         config["video_output"] = vid
+    if camera:
+        config["controls"] = camera.get_all_current_values()
+        w, h = camera.get_current_resolution()
+        fmt = getattr(camera, "current_format", "MJPG")
+        config["resolution"] = {"width": w, "height": h, "format": fmt}
     os.makedirs(config["image_output"], exist_ok=True)
     os.makedirs(config["video_output"], exist_ok=True)
     persist_config(config)

--- a/app/camera/controller.py
+++ b/app/camera/controller.py
@@ -20,6 +20,9 @@ class ThreadSafeCameraController:
         self.settings_lock = threading.Lock()
         self.stored_defaults = {}  # NEW: Store calculated defaults
         self.original_hardware_defaults = {}  # NEW: Store original hardware defaults before override
+        self.current_width = 0
+        self.current_height = 0
+        self.current_format = "MJPG"
 
         # Initialize camera (this now includes setting defaults)
         self._initialize_camera()
@@ -109,6 +112,9 @@ class ThreadSafeCameraController:
 
     def _set_camera_properties(self, width, height, fmt='MJPG'):
         """Set camera properties - only called after resolution detection"""
+        self.current_width = width
+        self.current_height = height
+        self.current_format = fmt
         self.cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*fmt))
         self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
         self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -7,6 +7,8 @@ def load_config():
     cfg = {
         "image_output": "timelapse",
         "video_output": "videos",
+        "controls": {},
+        "resolution": {"width": 640, "height": 480, "format": "MJPG"},
     }
     if os.path.exists(CONFIG_FILE):
         try:


### PR DESCRIPTION
## Summary
- track current resolution in `ThreadSafeCameraController`
- extend configuration loader with `controls` and `resolution` defaults
- save current controls and resolution when `save_config` endpoint is called

## Testing
- `python3 -m py_compile app/utils/config.py app/app.py app/camera/controller.py`

------
https://chatgpt.com/codex/tasks/task_e_688cd6c688dc832ca87bd65248d2c84b