### PR TITLE
Ensure timelapse uses config settings

### DIFF
--- a/app/camera/timelapse.py
+++ b/app/camera/timelapse.py
@@ -3,6 +3,13 @@ import cv2
 import time
 import threading
 
+try:
+    # When executed as part of the package
+    from ..utils.config import load_config
+except Exception:  # pragma: no cover - fallback for direct execution
+    # Fallback if the package layout isn't available
+    from app.utils.config import load_config
+
 class TimeLapseCapturer:
     def __init__(self, camera, output_dir="timelapse"):
         self.camera = camera
@@ -10,11 +17,37 @@ class TimeLapseCapturer:
         self.interval = 5
         self.running = False
         self.thread = None
+        self.prev_resolution = None
+        self.prev_format = None
+        self.prev_controls = None
         os.makedirs(self.output_dir, exist_ok=True)
 
     def start(self, interval):
         self.interval = interval
         if not self.running:
+            # Load latest config each start
+            cfg = load_config()
+
+            # Update output directory from config
+            self.output_dir = cfg.get("image_output", self.output_dir)
+            os.makedirs(self.output_dir, exist_ok=True)
+
+            # Preserve current preview settings
+            self.prev_resolution = self.camera.get_current_resolution()
+            self.prev_format = getattr(self.camera, "current_format", "MJPG")
+            self.prev_controls = self.camera.get_all_current_values()
+
+            # Apply configured resolution
+            res = cfg.get("resolution", {})
+            w = res.get("width", self.prev_resolution[0])
+            h = res.get("height", self.prev_resolution[1])
+            fmt = res.get("format", self.prev_format)
+            self.camera.set_resolution(w, h, fmt)
+
+            # Apply configured controls
+            for ctrl, value in cfg.get("controls", {}).items():
+                self.camera.set_control_value(ctrl, value)
+
             self.running = True
             self.thread = threading.Thread(target=self.capture_loop, daemon=True)
             self.thread.start()
@@ -23,6 +56,13 @@ class TimeLapseCapturer:
         self.running = False
         if self.thread:
             self.thread.join()
+        # Restore previous settings after timelapse ends
+        if self.prev_resolution:
+            w, h = self.prev_resolution
+            self.camera.set_resolution(w, h, self.prev_format)
+        if self.prev_controls:
+            for ctrl, value in self.prev_controls.items():
+                self.camera.set_control_value(ctrl, value)
 
     def capture_loop(self):
         count = 0


### PR DESCRIPTION
## Summary
- enforce timelapse capture to use config settings

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ce0e54728832cb566fe9a33612d55