### PR TITLE
Fix direct execution imports

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -13,7 +13,9 @@ import os
 # the import paths when no parent package is detected.
 if __package__ is None or __package__ == "":
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    sys.path.insert(0, os.path.abspath(os.path.join(script_dir, "..")))
+    # Make the "utils" and "camera" packages importable when executed directly
+    # as ``python app/app.py`` by prepending the ``app`` directory to ``sys.path``.
+    sys.path.insert(0, script_dir)
     from utils.config import load_config, persist_config
     from camera.controller import ThreadSafeCameraController
 else:

--- a/app/camera/timelapse.py
+++ b/app/camera/timelapse.py
@@ -4,11 +4,12 @@ import time
 import threading
 
 try:
-    # When executed as part of the package
+    # When imported via the ``app`` package (e.g. ``python -m app.app``)
     from ..utils.config import load_config
-except Exception:  # pragma: no cover - fallback for direct execution
-    # Fallback if the package layout isn't available
-    from app.utils.config import load_config
+except (ImportError, ValueError):  # pragma: no cover - fallback for direct execution
+    # When executed directly with ``python app/app.py`` the ``camera`` package
+    # is top-level, so we import from the sibling ``utils`` package instead.
+    from utils.config import load_config
 
 class TimeLapseCapturer:
     def __init__(self, camera, output_dir="timelapse"):


### PR DESCRIPTION
## Summary
- adjust module path handling in `app.py`
- fix fallback import logic in `timelapse.py`

## Testing
- `python -m py_compile app/app.py app/camera/timelapse.py`

------
https://chatgpt.com/codex/tasks/task_e_688ce38f7ff0832c906b4651c383b2ca