### PR TITLE
Move HTML to templates

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -1,4 +1,4 @@
-from flask import Flask, Response, request, jsonify, render_template_string
+from flask import Flask, Response, request, jsonify, render_template
 import os
 import signal
 import sys
@@ -106,209 +106,14 @@ def index():
     html_int_controls = render_controls(int_controls)
     html_other_controls = render_controls(other_controls)
 
-    return render_template_string('''
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Camera Stream</title>
-        {% raw %}
-        <style>
-            body { font-family: sans-serif; margin: 10px; }
-            .flex-container {
-                display: flex;
-                gap: 30px;
-                align-items: flex-start;
-            }
-            .video-container {
-                width: 800px;
-                height: 600px;
-                background: black;
-                border: 1px solid #ccc;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-            }
-            .video-container img {
-                width: 100%;
-                height: 100%;
-                object-fit: contain;
-            }
-            .controls-wrapper {
-                display: flex;
-                flex-direction: row;
-                gap: 20px;
-                flex-wrap: nowrap;
-            }
-            .column {
-                flex: 1;
-                display: flex;
-                flex-direction: column;
-                gap: 10px;
-            }
-            .control-group {
-                font-size: 14px;
-            }
-            .control-group input[type="range"],
-            .control-group select {
-                width: 100%;
-            }
-            .main-controls {
-                margin: 15px 0;
-            }
-            .main-controls button, .main-controls select {
-                margin-right: 10px;
-                padding: 6px 12px;
-            }
-        </style>
-        {% endraw %}
-    </head>
-    <body>
-        <h2>USB Camera Stream</h2>
-        <div class="main-controls">
-            <label>Camera:</label>
-            <select id="camera-select" onchange="changeCamera()">
-                {{ camera_options_html|safe }}
-            </select>
-            <label>Resolution:</label>
-            <select id="resolution" onchange="changeResolution()">
-                {{ options_html|safe }}
-            </select>
-            <button class="reset-button" onclick="resetControls()">Reset to Defaults</button>
-            <a href="/camera_status" target="_blank" class="status-link">View Camera Status</a>
-        </div>
-
-        <div class="flex-container">
-            <div class="video-container">
-                <img id="videoStream" src="/video_feed?t=0">
-            </div>
-            <div class="controls-wrapper">
-                <div class="column">
-                    {{ html_int_controls|safe }}
-                </div>
-                <div class="column">
-                    {{ html_other_controls|safe }}
-                </div>
-                <div class="column">
-                    <div class="control-group">
-                        <label for="timelapse-interval">Interval (sec):</label>
-                        <input type="number" id="timelapse-interval" value="5" min="1">
-                    </div>
-                    <div class="control-group" style="display: flex; gap: 10px;">
-                        <button onclick="startTimelapse()">Start Timelapse</button>
-                        <button onclick="stopTimelapse()">Stop Timelapse</button>
-                    </div>
-                    <div class="control-group" style="display: flex; gap: 10px;margin-top: 10px;">
-                        <button onclick="startRecording()">Start Recording</button>
-                        <button onclick="stopRecording()">Stop Recording</button>
-                    </div>
-                    <div class="control-group">
-                        <label for="image-output">Image Output:</label>
-                        <input type="text" id="image-output" value="{{ config['image_output'] }}">
-                    </div>
-                    <div class="control-group">
-                        <label for="video-output">Video Output:</label>
-                        <input type="text" id="video-output" value="{{ config['video_output'] }}">
-                    </div>
-                    <div class="control-group" style="margin-top: 10px;">
-                        <button onclick="saveConfig()">Save Config</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {% raw %}
-        <script>
-            function updateControl(controlName, value) {
-                fetch("/set_control", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ control: controlName, value: parseInt(value) })
-                }).then(resp => resp.json()).then(data => {
-                    const valueSpan = document.getElementById(controlName + "-value");
-                    if (valueSpan) valueSpan.textContent = value;
-                });
-            }
-
-            function resetControls() {
-                if (confirm("Reset all controls to stored defaults and reinitialize camera?")) {
-                    fetch("/reset_controls", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" }
-                    }).then(() => location.reload());
-                }
-            }
-
-            function changeResolution() {
-                const [fmt, w, h] = document.getElementById("resolution").value.split(",");
-                fetch("/set_resolution", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ width: parseInt(w), height: parseInt(h), format: fmt })
-                }).then(() => {
-                    document.getElementById("videoStream").src = "/video_feed?t=" + new Date().getTime();
-                });
-            }
-
-            function changeCamera() {
-                const dev = document.getElementById("camera-select").value;
-                fetch("/set_camera", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ device: dev })
-                }).then(() => location.reload());
-            }
-
-            function startTimelapse() {
-                const interval = parseInt(document.getElementById("timelapse-interval").value);
-                fetch("/start_timelapse", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ interval: interval })
-                }).then(resp => resp.json())
-                  .then(data => alert(data.message));
-            }
-            function stopTimelapse() {
-                fetch("/stop_timelapse", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" }
-                }).then(resp => resp.json())
-                  .then(data => alert(data.message));
-            }
-
-            function startRecording() {
-                fetch("/start_recording", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" }
-                }).then(resp => resp.json())
-                  .then(data => alert(data.message));
-            }
-            function stopRecording() {
-                fetch("/stop_recording", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" }
-                }).then(resp => resp.json())
-                  .then(data => alert(data.message));
-            }
-
-            function saveConfig() {
-                const img = document.getElementById("image-output").value;
-                const vid = document.getElementById("video-output").value;
-                fetch("/save_config", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ image_output: img, video_output: vid })
-                }).then(resp => resp.json())
-                  .then(() => alert("Config saved"));
-            }
-        </script>
-        {% endraw %}
-    </body>
-    </html>
-    ''', options_html=options_html,
-         camera_options_html=camera_options_html,
-         html_int_controls=html_int_controls,
-         html_other_controls=html_other_controls,
-         config=config)
+    return render_template(
+        'index.html',
+        options_html=options_html,
+        camera_options_html=camera_options_html,
+        html_int_controls=html_int_controls,
+        html_other_controls=html_other_controls,
+        config=config,
+    )
 
 
 @app.route('/set_camera', methods=['POST'])
@@ -437,69 +242,12 @@ def camera_status():
         current_marker = " ✓" if (res_w == w and res_h == h) else ""
         resolution_list += f"<li>{fmt} - {res_w}x{res_h}{current_marker}</li>"
 
-    return render_template_string('''
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title>Camera Status</title>
-            <style>
-                body { font-family: Arial, sans-serif; margin: 20px; }
-                table { border-collapse: collapse; width: 100%; margin: 20px 0; }
-                th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
-                th { background-color: #f2f2f2; }
-                .section { margin: 30px 0; }
-                .current-resolution { background-color: #e8f5e8; padding: 10px; border-radius: 5px; }
-                ul { list-style-type: none; padding: 0; }
-                li { padding: 5px; margin: 2px 0; background-color: #f9f9f9; border-radius: 3px; }
-            </style>
-        </head>
-        <body>
-            <h1>Camera Status</h1>
-
-            <div class="section">
-                <h2>Current Resolution</h2>
-                <div class="current-resolution">
-                    <strong>{{ current_resolution }}</strong>
-                </div>
-            </div>
-
-            <div class="section">
-                <h2>Available Resolutions</h2>
-                <ul>
-                    {{ resolution_list|safe }}
-                </ul>
-            </div>
-
-            <div class="section">
-                <h2>Camera Controls</h2>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Control Name</th>
-                            <th>Type</th>
-                            <th>Current Value</th>
-                            <th>Min</th>
-                            <th>Max</th>
-                            <th>Step</th>
-                            <th>Hardware Default</th>
-                            <th>Stored Default</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{ controls_html|safe }}
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="section">
-                <button onclick="window.close()" style="padding: 10px 15px; background-color: #6c757d; color: white; border: none; border-radius: 5px;">Close</button>
-            </div>
-        </body>
-        </html>
-    ''',
-    current_resolution=f"{w}x{h}",
-    resolution_list=resolution_list,
-    controls_html=controls_html)
+    return render_template(
+        'status.html',
+        current_resolution=f"{w}x{h}",
+        resolution_list=resolution_list,
+        controls_html=controls_html,
+    )
 
 
 @app.route('/camera_status_json')

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,0 +1,81 @@
+body { font-family: sans-serif; margin: 10px; }
+.flex-container {
+    display: flex;
+    gap: 30px;
+    align-items: flex-start;
+}
+.video-container {
+    width: 800px;
+    height: 600px;
+    background: black;
+    border: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.video-container img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+.controls-wrapper {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    flex-wrap: nowrap;
+}
+.column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.control-group {
+    font-size: 14px;
+}
+.control-group input[type="range"],
+.control-group select {
+    width: 100%;
+}
+.main-controls {
+    margin: 15px 0;
+}
+.main-controls button,
+.main-controls select {
+    margin-right: 10px;
+    padding: 6px 12px;
+}
+
+/* Camera status styles */
+.table-bordered {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 20px 0;
+}
+.table-bordered th,
+.table-bordered td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+.table-bordered th {
+    background-color: #f2f2f2;
+}
+.section {
+    margin: 30px 0;
+}
+.current-resolution {
+    background-color: #e8f5e8;
+    padding: 10px;
+    border-radius: 5px;
+}
+ul.resolution-list {
+    list-style-type: none;
+    padding: 0;
+}
+ul.resolution-list li {
+    padding: 5px;
+    margin: 2px 0;
+    background-color: #f9f9f9;
+    border-radius: 3px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Camera Stream</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <h2>USB Camera Stream</h2>
+    <div class="main-controls">
+        <label>Camera:</label>
+        <select id="camera-select" onchange="changeCamera()">
+            {{ camera_options_html|safe }}
+        </select>
+        <label>Resolution:</label>
+        <select id="resolution" onchange="changeResolution()">
+            {{ options_html|safe }}
+        </select>
+        <button class="reset-button" onclick="resetControls()">Reset to Defaults</button>
+        <a href="/camera_status" target="_blank" class="status-link">View Camera Status</a>
+    </div>
+
+    <div class="flex-container">
+        <div class="video-container">
+            <img id="videoStream" src="/video_feed?t=0">
+        </div>
+        <div class="controls-wrapper">
+            <div class="column">
+                {{ html_int_controls|safe }}
+            </div>
+            <div class="column">
+                {{ html_other_controls|safe }}
+            </div>
+            <div class="column">
+                <div class="control-group">
+                    <label for="timelapse-interval">Interval (sec):</label>
+                    <input type="number" id="timelapse-interval" value="5" min="1">
+                </div>
+                <div class="control-group" style="display: flex; gap: 10px;">
+                    <button onclick="startTimelapse()">Start Timelapse</button>
+                    <button onclick="stopTimelapse()">Stop Timelapse</button>
+                </div>
+                <div class="control-group" style="display: flex; gap: 10px;margin-top: 10px;">
+                    <button onclick="startRecording()">Start Recording</button>
+                    <button onclick="stopRecording()">Stop Recording</button>
+                </div>
+                <div class="control-group">
+                    <label for="image-output">Image Output:</label>
+                    <input type="text" id="image-output" value="{{ config['image_output'] }}">
+                </div>
+                <div class="control-group">
+                    <label for="video-output">Video Output:</label>
+                    <input type="text" id="video-output" value="{{ config['video_output'] }}">
+                </div>
+                <div class="control-group" style="margin-top: 10px;">
+                    <button onclick="saveConfig()">Save Config</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function updateControl(controlName, value) {
+            fetch("/set_control", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ control: controlName, value: parseInt(value) })
+            }).then(resp => resp.json()).then(data => {
+                const valueSpan = document.getElementById(controlName + "-value");
+                if (valueSpan) valueSpan.textContent = value;
+            });
+        }
+
+        function resetControls() {
+            if (confirm("Reset all controls to stored defaults and reinitialize camera?")) {
+                fetch("/reset_controls", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" }
+                }).then(() => location.reload());
+            }
+        }
+
+        function changeResolution() {
+            const [fmt, w, h] = document.getElementById("resolution").value.split(",");
+            fetch("/set_resolution", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ width: parseInt(w), height: parseInt(h), format: fmt })
+            }).then(() => {
+                document.getElementById("videoStream").src = "/video_feed?t=" + new Date().getTime();
+            });
+        }
+
+        function changeCamera() {
+            const dev = document.getElementById("camera-select").value;
+            fetch("/set_camera", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ device: dev })
+            }).then(() => location.reload());
+        }
+
+        function startTimelapse() {
+            const interval = parseInt(document.getElementById("timelapse-interval").value);
+            fetch("/start_timelapse", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ interval: interval })
+            }).then(resp => resp.json())
+              .then(data => alert(data.message));
+        }
+        function stopTimelapse() {
+            fetch("/stop_timelapse", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" }
+            }).then(resp => resp.json())
+              .then(data => alert(data.message));
+        }
+
+        function startRecording() {
+            fetch("/start_recording", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" }
+            }).then(resp => resp.json())
+              .then(data => alert(data.message));
+        }
+        function stopRecording() {
+            fetch("/stop_recording", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" }
+            }).then(resp => resp.json())
+              .then(data => alert(data.message));
+        }
+
+        function saveConfig() {
+            const img = document.getElementById("image-output").value;
+            const vid = document.getElementById("video-output").value;
+            fetch("/save_config", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ image_output: img, video_output: vid })
+            }).then(resp => resp.json())
+              .then(() => alert("Config saved"));
+        }
+    </script>
+</body>
+</html>

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Camera Status</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <h1>Camera Status</h1>
+
+    <div class="section">
+        <h2>Current Resolution</h2>
+        <div class="current-resolution">
+            <strong>{{ current_resolution }}</strong>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Available Resolutions</h2>
+        <ul class="resolution-list">
+            {{ resolution_list|safe }}
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Camera Controls</h2>
+        <table class="table-bordered">
+            <thead>
+                <tr>
+                    <th>Control Name</th>
+                    <th>Type</th>
+                    <th>Current Value</th>
+                    <th>Min</th>
+                    <th>Max</th>
+                    <th>Step</th>
+                    <th>Hardware Default</th>
+                    <th>Stored Default</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ controls_html|safe }}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="section">
+        <button onclick="window.close()" class="btn btn-secondary">Close</button>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add static CSS file and templates
- render index and status pages from templates instead of strings

## Testing
- `python -m py_compile app/server.py`
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688d31add540832c8c2300ef6b4d329d