### PR TITLE
Block video feed on frame queue

### DIFF
--- a/app/camera.py
+++ b/app/camera.py
@@ -120,6 +120,13 @@ class ThreadSafeCameraController:
             frame = self.frame_queue.get_nowait()
         return frame
 
+    def get_frame_blocking(self, timeout=None):
+        """Return the next frame, blocking until one is available."""
+        try:
+            return self.frame_queue.get(block=True, timeout=timeout)
+        except queue.Empty:
+            return None
+
     def _get_supported_resolutions(self):
         cmd = f"v4l2-ctl --device={self.device_path} --list-formats-ext"
         result = subprocess.run(

--- a/app/server.py
+++ b/app/server.py
@@ -283,10 +283,9 @@ def video_feed():
             if not camera:
                 time.sleep(0.1)
                 continue
-            frame = camera.get_latest_frame()
+            frame = camera.get_frame_blocking()
             if frame:
                 yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + frame + b"\r\n")
-            time.sleep(0.033)
 
     return Response(generate(), mimetype="multipart/x-mixed-replace; boundary=frame")
 


### PR DESCRIPTION
## Summary
- Add blocking `get_frame_blocking` method to `ThreadSafeCameraController`
- Use blocking frame retrieval in `video_feed` and remove polling sleep

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688e868afa70832c84befb17669249ea